### PR TITLE
#hostlistへの投稿メッセージの改善提案

### DIFF
--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -169,7 +169,7 @@ class Hosting(CogMixin):
             int(port)
         except ValueError:
             raise commands.BadArgument
-        ip_port_comments = f"{ip}:{port} |  {' '.join(comment)}"
+        ip_port_comments = f"{ip}:{port} | {' '.join(comment)}"
         host_message = f"{user.mention}, {ip_port_comments}"
 
         not_private = not ctx.message.channel.is_private
@@ -211,7 +211,7 @@ class Hosting(CogMixin):
             int(port)
         except ValueError:
             raise commands.BadArgument
-        ip_port_comments = f"{ip}:{port} |  {' '.join(comment)}"
+        ip_port_comments = f"{ip}:{port} | {' '.join(comment)}"
         host_message = f"{user.mention}, {ip_port_comments}"
 
         not_private = not ctx.message.channel.is_private

--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -30,6 +30,10 @@ def get_echo_packet(is_sokuroll=None):
     return PACKET_TO_SOKUROLL if is_sokuroll else PACKET_TO_HOST
 
 
+def get_hostlist_ch(bot):
+    return discord.utils.get(bot.get_all_channels(), name="hostlist")
+
+
 class EchoClientProtocol:
     def __init__(self, bot, user, host_message, message, echo_packet):
         self.bot = bot
@@ -152,9 +156,6 @@ class Hosting(CogMixin):
         self.observer = discord.compat.create_task(
             HostListObserver.update_hostlist())
 
-    def get_hostlist_ch(self):
-        return discord.utils.get(self.bot.get_all_channels(), name="hostlist")
-
     @commands.command(pass_context=True)
     async def host(self, ctx, ip_port: str, *comment):
         """
@@ -183,7 +184,7 @@ class Hosting(CogMixin):
 
         await self.bot.whisper("ホストの検知を開始します。")
         message = await self.bot.send_message(
-            self.get_hostlist_ch(),
+            get_hostlist_ch(self.bot),
             host_message)
 
         connect = self.bot.loop.create_datagram_endpoint(
@@ -225,7 +226,7 @@ class Hosting(CogMixin):
 
         await self.bot.whisper("ホストの検知を開始します。")
         message = await self.bot.send_message(
-            self.get_hostlist_ch(),
+            get_hostlist_ch(self.bot),
             host_message)
 
         connect = self.bot.loop.create_datagram_endpoint(

--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -190,11 +190,6 @@ class Hosting(CogMixin):
             await self.bot.delete_message(ctx.message)
             raise errors.OnlyPrivateMessage
 
-        # 自分の投稿が残っていたら何もせず終了
-        async for message in self.bot.logs_from(self.get_hostlist_ch()):
-            if message.mentions and message.mentions[0] == user:
-                return
-
         await self.bot.whisper("ホストの検知を開始します。")
         connect = self.bot.loop.create_datagram_endpoint(
             lambda: EchoClientProtocol(
@@ -225,11 +220,6 @@ class Hosting(CogMixin):
         if not_private:
             await self.bot.delete_message(ctx.message)
             raise errors.OnlyPrivateMessage
-
-        # 自分の投稿が残っていたら何もせず終了
-        async for message in self.bot.logs_from(self.get_hostlist_ch()):
-            if message.mentions and message.mentions[0] == user:
-                return
 
         await self.bot.whisper("ホストの検知を開始します。")
         connect = self.bot.loop.create_datagram_endpoint(

--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -35,10 +35,9 @@ def get_hostlist_ch(bot):
 
 
 class EchoClientProtocol:
-    def __init__(self, user, host_message, message, echo_packet):
+    def __init__(self, user, host_message, echo_packet):
         self.user = user
         self.host_message = host_message
-        self.message = message
         self.echo_packet = echo_packet
         self.transport = None
         self.start_datetime = datetime.now()
@@ -140,17 +139,15 @@ class HostListObserver:
                     continue
 
                 host_messages.append(host.get_host_message(cls.WAIT * 3))
-                await cls._bot.edit_message(
-                        host.message,
-                        host_messages[-1])
 
-            post_message = base_message.format(len(host_messages))
+            post_message = (
+                base_message.format(len(host_messages)) +
+                "\n".join(host_messages))
             await cls._bot.edit_message(message, post_message)
 
     @classmethod
     async def close(cls, host, close_message):
         await cls._bot.send_message(host.user, close_message)
-        await cls._bot.delete_message(host.message)
         cls._remove(host)
         host.transport.close()
 
@@ -199,15 +196,10 @@ class Hosting(CogMixin):
                 return
 
         await self.bot.whisper("ホストの検知を開始します。")
-        message = await self.bot.send_message(
-            get_hostlist_ch(self.bot),
-            host_message)
-
         connect = self.bot.loop.create_datagram_endpoint(
             lambda: EchoClientProtocol(
                 user,
                 host_message,
-                message,
                 get_echo_packet(is_sokuroll=False)),
             remote_addr=(ip, int(port)))
         _, protocol = await connect
@@ -240,15 +232,10 @@ class Hosting(CogMixin):
                 return
 
         await self.bot.whisper("ホストの検知を開始します。")
-        message = await self.bot.send_message(
-            get_hostlist_ch(self.bot),
-            host_message)
-
         connect = self.bot.loop.create_datagram_endpoint(
             lambda: EchoClientProtocol(
                 user,
                 ":regional_indicator_r:" + host_message,
-                message,
                 get_echo_packet(is_sokuroll=True)),
             remote_addr=(ip, int(port)))
         _, protocol = await connect

--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -123,13 +123,14 @@ class HostListObserver:
             base_message.format(0))
 
         while True:
-            for host in cls._host_list:
+            host_list = cls._host_list[:]
+            for host in host_list:
                 host.try_echo()
 
             await asyncio.sleep(cls.WAIT.seconds)
 
             host_messages = list()
-            for host in cls._host_list:
+            for host in host_list:
                 elapsed_time = host.elapsed_time_from_ack()
                 if elapsed_time >= cls.LIFETIME:
                     close_message = (


### PR DESCRIPTION
#5 を改善するための修正提案です。

Discord API(edit_message)の実行コストが処理の重さの主要因と考えられます。
仮定が正しければ、Discord APIを呼び出す回数を最小限に抑えることで、現象が改善される可能性があります。

本対応では、#hostlistへの投稿が、1ユーザにつき1メッセージとなっているところを、全ての投稿を1メッセージにまとめることで、Discord APIを呼び出す回数を抑止しています。