### PR TITLE
#hostlistへの投稿を取り下げる、closeコマンドを実装（復活）。

### DIFF
--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -123,6 +123,9 @@ class HostPostAsset:
             elapsed_time,
             self.host_message])
 
+    def get_close_message(self):
+        return "一定時間ホストが検知されなかったため、募集を終了します。"
+
     def should_close(self):
         return self.protocol.is_expired()
 
@@ -153,10 +156,7 @@ class HostListObserver:
             for host in host_list:
                 elapsed_time = host.protocol.elapsed_time_from_ack()
                 if host.should_close():
-                    close_message = (
-                        "一定時間ホストが検知されなかったため、"
-                        "募集を終了します。")
-                    await cls.close(host, close_message)
+                    await cls.close(host)
                     continue
 
                 ack_loses = elapsed_time >= (cls.WAIT * 3)
@@ -168,7 +168,8 @@ class HostListObserver:
             await cls._bot.edit_message(message, post_message)
 
     @classmethod
-    async def close(cls, host, close_message):
+    async def close(cls, host):
+        close_message = host.get_close_message()
         await cls._bot.send_message(host.user, close_message)
         cls._remove(host)
         host.protocol.transport.close()

--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -207,10 +207,7 @@ class Hosting(CogMixin):
         ip_port_comments = f"{ip}:{port} | {' '.join(comment)}"
         host_message = f"{user.mention}, {ip_port_comments}"
 
-        not_private = not ctx.message.channel.is_private
-        if not_private:
-            await self.bot.delete_message(ctx.message)
-            raise errors.OnlyPrivateMessage
+        await self._validate_direct_message(ctx)
 
         await self.bot.whisper("ホストの検知を開始します。")
         connect = self.bot.loop.create_datagram_endpoint(
@@ -241,10 +238,7 @@ class Hosting(CogMixin):
         sokuroll_icon = ":regional_indicator_r:"
         host_message = f"{sokuroll_icon} {user.mention}, {ip_port_comments}"
 
-        not_private = not ctx.message.channel.is_private
-        if not_private:
-            await self.bot.delete_message(ctx.message)
-            raise errors.OnlyPrivateMessage
+        await self._validate_direct_message(ctx)
 
         await self.bot.whisper("ホストの検知を開始します。")
         connect = self.bot.loop.create_datagram_endpoint(
@@ -253,3 +247,9 @@ class Hosting(CogMixin):
         _, protocol = await connect
         host = HostPostAsset(user, host_message, protocol)
         HostListObserver.append(host)
+
+    async def _validate_direct_message(self, ctx):
+        not_private = not ctx.message.channel.is_private
+        if not_private:
+            await self.bot.delete_message(ctx.message)
+            raise errors.OnlyPrivateMessage


### PR DESCRIPTION
ホストの自動監視機能を追加するにあたり、暫定的にclientコマンド、及びcloseコマンドが廃止となっていました。
将来的な、clientコマンドの再実装を念頭に、closeコマンドを再実装しました。

closeコマンドを実行すると、即座にユーザーの全投稿を取り下げます。