### PR TITLE
ホスト監視時に未知のパケットを受信したときの表示アイコン提案

### DIFF
--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -64,6 +64,11 @@ class HostStatus:
             not self.matching and
             not self.watchable)
 
+    def __str__(self):
+        return " ".join([
+            ":crossed_swords:" if self.matching else ":o:",
+            ":eye:" if self.watchable else ":see_no_evil:"])
+
 
 class EchoClientProtocol:
     def __init__(self, echo_packet, lifetime=timedelta(seconds=20)):
@@ -123,8 +128,7 @@ class HostPostAsset:
         elapsed_seconds = (datetime.now() - self.start_datetime).seconds
         elapsed_time = f"{int(elapsed_seconds / 60)}m{elapsed_seconds % 60}s"
         return " ".join([
-            ":crossed_swords:" if host_status.matching else ":o:",
-            ":eye:" if host_status.watchable else ":see_no_evil:",
+            str(host_status),
             elapsed_time,
             self.host_message])
 

--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -36,6 +36,9 @@ def get_hostlist_ch(bot):
 
 class HostStatus:
     def __init__(self):
+        self.reset()
+
+    def reset(self):
         self.hosting = False
         self.matching = False
         self.watchable = False
@@ -54,9 +57,7 @@ class HostStatus:
             self.matching = True
             self.watchable = self.watchable
         else:
-            self.hosting = False
-            self.matching = False
-            self.watchable = False
+            self.reset()
 
     def is_unknown(self):
         return (

--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -66,6 +66,9 @@ class HostStatus:
             not self.watchable)
 
     def __str__(self):
+        if self.is_unknown():
+            return ":question:"
+
         return " ".join([
             ":crossed_swords:" if self.matching else ":o:",
             ":eye:" if self.watchable else ":see_no_evil:"])
@@ -122,14 +125,13 @@ class HostPostAsset:
         self.start_datetime = datetime.now()
 
     def get_host_message(self, ack_loses):
-        host_status = self.protocol.host_status
-        if ack_loses or not host_status.hosting:
+        if ack_loses:
             return f":x: {self.host_message}"
 
         elapsed_seconds = (datetime.now() - self.start_datetime).seconds
         elapsed_time = f"{int(elapsed_seconds / 60)}m{elapsed_seconds % 60}s"
         return " ".join([
-            str(host_status),
+            str(self.protocol.host_status),
             elapsed_time,
             self.host_message])
 


### PR DESCRIPTION
ホスト監視機能は、特定のパケットを送信した応答によって、ホストの状態を判断しています。
この応答のパケットは、極稀に未知のパケットが返ることがあり、その場合は :x: を表示しています。

ホスト間通信は正常であるため、通信断と区別する目的で、 ❓ を表示するような変更の提案です。

この提案を取り込んだ場合、以下の副作用が生じます:
* 募集開始直後にホストが立っていない場合、 ❓ を表示した後 :x: の表示に切り替わる