### PR TITLE
ホスト検知を行わない対戦募集を投稿する、clientコマンドを実装（復活）。

### DIFF
--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -89,7 +89,7 @@ class HostStatus:
             ":eye:" if self.watchable else ":see_no_evil:"])
 
 
-class EchoClientProtocol:
+class Th123HostProtocol:
     def __init__(self, echo_packet, *, lifetime=None, ack_lifetime=None):
         self.echo_packet = echo_packet
         self.lifetime = lifetime or Lifetime(timedelta(seconds=20))
@@ -278,7 +278,7 @@ class Hosting(CogMixin):
 
         await self.bot.whisper("ホストの検知を開始します。")
         connect = self.bot.loop.create_datagram_endpoint(
-            lambda: EchoClientProtocol(get_echo_packet(sokuroll_uses)),
+            lambda: Th123HostProtocol(get_echo_packet(sokuroll_uses)),
             remote_addr=(ip.exploded, port))
         _, protocol = await connect
         host = HostPostAsset(user, host_message, protocol)

--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -89,14 +89,27 @@ class HostStatus:
             ":eye:" if self.watchable else ":see_no_evil:"])
 
 
-class Th123HostProtocol:
+class Th123DatagramProtocol(asyncio.DatagramProtocol):
+    def __init__(self, lifetime, ack_lifetime):
+        self.lifetime = lifetime
+        self.ack_lifetime = ack_lifetime
+
+    def try_echo(self):
+        pass
+
+    def discard(self):
+        pass
+
+
+class Th123HostProtocol(Th123DatagramProtocol):
     def __init__(self, echo_packet, *, lifetime=None, ack_lifetime=None):
+        super().__init__(
+            lifetime or Lifetime(timedelta(seconds=20)),
+            ack_lifetime or Lifetime(timedelta(seconds=6)))
         self.echo_packet = echo_packet
-        self.lifetime = lifetime or Lifetime(timedelta(seconds=20))
 
         self.transport = None
         self.host_status = HostStatus()
-        self.ack_lifetime = ack_lifetime or Lifetime(timedelta(seconds=6))
 
     def connection_made(self, transport):
         self.transport = transport

--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -142,7 +142,21 @@ class Th123HostProtocol(Th123DatagramProtocol):
             self.transport.close()
 
 
-class HostPostAsset:
+class PostAsset:
+    def get_host_message(self):
+        raise NotImplementedError
+
+    def get_close_message(self):
+        raise NotImplementedError
+
+    def should_close(self):
+        raise NotImplementedError
+
+    def terminate(self):
+        raise NotImplementedError
+
+
+class HostPostAsset(PostAsset):
     def __init__(self, user, host_message, protocol):
         self.user = user
         self.host_message = host_message


### PR DESCRIPTION
ホストの自動監視機能を追加するにあたり、暫定的にclientコマンドが廃止となっていました。
リファクタにより、技術的な課題が解消されたため、clientコマンドを再実装しました。
