### PR TITLE
Hosting/ClientMatchingのタスク生成タイミングの見直し

### DIFF
--- a/cogs/client_matching.py
+++ b/cogs/client_matching.py
@@ -152,11 +152,6 @@ class Th123HolePunchingProtocol:
 
 
 async def task_func(bot):
-    await asyncio.sleep(5)
-    transport, protocol = await bot.loop.create_datagram_endpoint(
-            Th123HolePunchingProtocol,
-            local_addr=('0.0.0.0', 38100))
-
     base_message = "上海は空いています。"
     message = await bot.send_message(
         get_client_ch(bot), base_message
@@ -167,7 +162,7 @@ async def task_func(bot):
         await asyncio.sleep(3)
 
         # 閉じていればサーバー再起動
-        if transport.is_closing():
+        if transport is None or transport.is_closing():
             transport, protocol = await bot.loop.create_datagram_endpoint(
                     Th123HolePunchingProtocol,
                     local_addr=('0.0.0.0', 38100))
@@ -199,4 +194,8 @@ async def task_func(bot):
 
 class ClientMatching(CogMixin):
     def __init__(self, bot):
-        discord.compat.create_task(task_func(bot))
+        self.bot = bot
+
+    async def on_ready(self):
+        discord.compat.create_task(task_func(self.bot))
+        await super().on_ready()

--- a/cogs/client_matching.py
+++ b/cogs/client_matching.py
@@ -9,8 +9,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def get_client_ch(bot):
     return discord.utils.get(bot.get_all_channels(), name="client")
+
 
 def atob(address):
     return (address[0]).to_bytes(2, byteorder='big')+socket.inet_aton(address[1])
@@ -65,6 +67,7 @@ packet_07 = binascii.unhexlify(
 # host to client
 packet_0d_sp = binascii.unhexlify("0d0203")
 packet_0d_parts = [binascii.unhexlify(p) for p in ["0d03", "030200000000"]]
+
 
 def get_packet_0d(ack):
     return packet_0d_parts[0]+(ack).to_bytes(4, byteorder='little')+packet_0d_parts[1]
@@ -160,7 +163,9 @@ async def task_func(bot):
     )
 
     while True:
-        await asyncio.sleep(3) #クロック
+        # クロック
+        await asyncio.sleep(3)
+
         # 閉じていればサーバー再起動
         if transport.is_closing():
             transport, protocol = await bot.loop.create_datagram_endpoint(
@@ -175,7 +180,7 @@ async def task_func(bot):
         if protocol.profile_name is None:
             message = await bot.edit_message(message, base_message)
         else:
-            #一瞬メッセージを送信して通知を付ける
+            # 一瞬メッセージを送信して通知を付ける
             if message.content == base_message:
                 notify = await bot.send_message(
                     get_client_ch(bot), ".")
@@ -188,9 +193,9 @@ async def task_func(bot):
         if protocol.punched_flag:
             message = await bot.edit_message(
                     message, ":".join(map(str, protocol.client_addr)) + "に凸ができます。")
-            transport.close() #接続を切って通知
+            # 接続を切って通知を180秒間表示し続ける
+            transport.close()
             await asyncio.sleep(180)
-    
 
 class ClientMatching(CogMixin):
     def __init__(self, bot):

--- a/cogs/hosting.py
+++ b/cogs/hosting.py
@@ -288,7 +288,10 @@ class HostListObserver:
 class Hosting(CogMixin):
     def __init__(self, bot):
         self.bot = bot
-        self.observer = None
+
+    async def on_ready(self):
+        discord.compat.create_task(HostListObserver.task_func(self.bot))
+        await super().on_ready()
 
     @checks.only_private()
     @commands.command(pass_context=True)
@@ -298,10 +301,6 @@ class Hosting(CogMixin):
         約20秒間ホストが検知されなければ、自動で投稿を取り下げます。
         募集例「!host 198.51.100.123:10800 霊夢　レート1500　どなたでもどうぞ！」
         """
-        if self.observer is None:
-            self.observer = discord.compat.create_task(
-                HostListObserver.task_func(self.bot))
-
         user = ctx.message.author
         await self.invite_as_host(user, ip_port, comment, sokuroll_uses=False)
 
@@ -313,10 +312,6 @@ class Hosting(CogMixin):
         約20秒間ホストが検知されなければ、自動で投稿を取り下げます。
         募集例「!rhost 198.51.100.123:10800 霊夢　レート1500　どなたでもどうぞ！」
         """
-        if self.observer is None:
-            self.observer = discord.compat.create_task(
-                HostListObserver.task_func(self.bot))
-
         user = ctx.message.author
         await self.invite_as_host(user, ip_port, comment, sokuroll_uses=True)
 
@@ -351,10 +346,6 @@ class Hosting(CogMixin):
         投稿から60分経過するか、closeコマンドで、投稿を取り下げます。
         募集例「!client 霊夢　レート1500　どなたでもどうぞ！」
         """
-        if self.observer is None:
-            self.observer = discord.compat.create_task(
-                HostListObserver.task_func(self.bot))
-
         user = ctx.message.author
         message_body = f"{user.mention}, {' '.join(comment)}"
 


### PR DESCRIPTION
リファクタリング案件です。

従来の実装では、[shanghai.py の load_cogs()](https://github.com/stanak/th123discord/blob/063e0ea20298ce4b76577e599413609042ddc047/shanghai.py#L83-88
)で、[CogMixin.setup()](https://github.com/stanak/th123discord/blob/063e0ea20298ce4b76577e599413609042ddc047/cogs/cogmixin.py#L3-5)が呼ばれたとき（＝CogMixinを継承したクラスの『\_\_init__()』が呼ばれたとき）に、タスクを生成していました。

この場合、タスク生成時点ではbotは起動していない（Discordへログインしていない）ため、メッセージの投稿等はできません。
この影響により、bot起動時に投稿したいメッセージは、別途キッカケを待ち受けて、投稿する実装でした。

このPRでは、CogMixinを継承したクラスの『on_ready()』が呼ばれたときに、タスクを生成するように変更しています。
『on_ready()』は、botの準備が出来た後（≒メッセージ投稿等が可能となった後）に呼ばれるため、先の不都合が解消されます。