### PR TITLE
IP/Portクラスの実装

### DIFF
--- a/cogs/common/networks.py
+++ b/cogs/common/networks.py
@@ -1,0 +1,53 @@
+from ipaddress import IPv4Address as ipv4
+from typing import Any, Iterable
+import unicodedata
+
+
+class IpPort:
+    __construct_key = object()
+
+    def __init__(self, ip: ipv4, port: int, *, key: object) -> None:
+        assert key == self.__construct_key, \
+            'PortIp object must be created using PortIp.create methods'
+
+        self._ip = ip
+        self._port = port
+
+    @classmethod
+    def create(cls, ip: Any, port: Any) -> 'IpPort':
+        return IpPort(ipv4(ip), int(port), key=cls.__construct_key)
+
+    @classmethod
+    def create_with_str(cls, ip_port: str) -> 'IpPort':
+        ip, port = unicodedata.normalize('NFKC', ip_port).split(':', 1)
+        ip = ipv4(ip)
+        port = int(port)
+        if port not in range(0x0000, 0xffff):
+            raise ValueError
+        return IpPort(ip, port, key=cls.__construct_key)
+
+    @classmethod
+    def create_with_bin(cls, port_ip: bytes) -> 'IpPort':
+        port, ip = (int.from_bytes(port_ip[:2], 'big'), ipv4(port_ip[2:]))
+        return IpPort(ip, port, key=cls.__construct_key)
+
+    def ipaddr(self) -> ipv4:
+        return self._ip
+
+    def port(self) -> int:
+        return self._port
+
+    def __str__(self) -> str:
+        return f'{self._ip.exploded}:{self._port}'
+
+    def __bytes__(self) -> bytes:
+        return self.port().to_bytes(2, 'big') + self._ip.packed
+
+    def __iter__(self) -> Iterable:
+        yield self._ip.exploded
+        yield self._port
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/tests/cogs/common/test_networks.py
+++ b/tests/cogs/common/test_networks.py
@@ -1,0 +1,81 @@
+import unittest
+
+from cogs.common import networks
+
+
+class TestIpPort(unittest.TestCase):
+    def test_dunder_init(self):
+        with self.assertRaises(AssertionError):
+            networks.IpPort(None, None, key=None)
+
+        with self.assertRaises(AssertionError):
+            networks.IpPort(None, None, key=object())
+
+    def test_create(self):
+        self.assertIsInstance(
+            networks.IpPort.create('192.0.2.0', 7500),
+            networks.IpPort)
+
+        self.assertIsInstance(
+            networks.IpPort.create('127.0.0.1', 38100),
+            networks.IpPort)
+
+        self.assertIsInstance(
+            networks.IpPort.create('192.168.1.1', 10800),
+            networks.IpPort)
+
+    def test_create_with_str(self):
+        self.assertIsInstance(
+            networks.IpPort.create_with_str('192.0.2.0:7500'),
+            networks.IpPort)
+
+        self.assertIsInstance(
+            networks.IpPort.create_with_str('127.0.0.1:38100'),
+            networks.IpPort)
+
+        self.assertIsInstance(
+            networks.IpPort.create_with_str('192.168.1.1:10800'),
+            networks.IpPort)
+
+    def test_create_with_bin(self):
+        self.assertIsInstance(
+            networks.IpPort.create_with_bin(b'\x1dL\xc0\x00\x02\x00'),
+            networks.IpPort)
+
+        self.assertIsInstance(
+            networks.IpPort.create_with_bin(b'\x94\xd4\x7f\x00\x00\x01'),
+            networks.IpPort)
+
+        self.assertIsInstance(
+            networks.IpPort.create_with_bin(b'*0\xc0\xa8\x01\x01'),
+            networks.IpPort)
+
+    def test_dunder_str(self):
+        ipport = networks.IpPort.create('192.0.2.0', 7500)
+        self.assertEqual(str(ipport), '192.0.2.0:7500')
+
+        ipport = networks.IpPort.create_with_str('127.0.0.1:38100')
+        self.assertEqual(str(ipport), '127.0.0.1:38100')
+
+        ipport = networks.IpPort.create_with_bin(b'*0\xc0\xa8\x01\x01')
+        self.assertEqual(str(ipport), '192.168.1.1:10800')
+
+    def test_dunder_bin(self):
+        ipport = networks.IpPort.create('192.0.2.0', 7500)
+        self.assertEqual(bytes(ipport), b'\x1dL\xc0\x00\x02\x00')
+
+        ipport = networks.IpPort.create_with_str('127.0.0.1:38100')
+        self.assertEqual(bytes(ipport), b'\x94\xd4\x7f\x00\x00\x01')
+
+        ipport = networks.IpPort.create_with_bin(b'*0\xc0\xa8\x01\x01')
+        self.assertEqual(bytes(ipport), b'*0\xc0\xa8\x01\x01')
+
+    def test_dunder_iter(self):
+        ipport = networks.IpPort.create('192.0.2.0', 7500)
+        self.assertEqual(tuple(ipport), ('192.0.2.0', 7500))
+
+        ipport = networks.IpPort.create_with_str('127.0.0.1:38100')
+        self.assertEqual(tuple(ipport), ('127.0.0.1', 38100))
+
+        ipport = networks.IpPort.create_with_bin(b'*0\xc0\xa8\x01\x01')
+        self.assertEqual(tuple(ipport), ('192.168.1.1', 10800))


### PR DESCRIPTION
hosting.pyと、client_maching.pyとで、共通して利用するIP/Portをクラスに切り出しました。（cogs.common.networks.IpPort）
文字列変換、バイト列変換、タプル変換、それぞれに対応しています。

今回、IpPortクラスに切り出すにあたり、ユニットテストコードを合わせて実装しています。
テスト観点が十分か、確認していただけると幸いです。